### PR TITLE
ci: lint code on every push changes to src/**

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,21 @@
+---
+name: Lint Code
+description: Run eslint and prettier --check
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    paths:
+      - src/**
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+
+      - name: Install npm dependencies
+        run: npm ci --include=dev
+
+      - name: Run npm run lint
+        run: npm run lint

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "dev": "vite --host --port 4000",
         "build": "cross-env NODE_OPTIONS=--max-old-space-size=8192 tsc && vite build",
         "preview": "vite preview",
-        "lint": "eslint src/**/*.{js,jsx,ts,tsx,json}",
+        "lint": "eslint src/ && prettier --check src/",
         "lint:fix": "eslint --fix src/**/*.{js,jsx,ts,tsx,json}",
         "format": "prettier --write src/**/*.{ts,tsx} --config ./.prettierrc"
     },


### PR DESCRIPTION
This PR adds continuous integration in your repo that will lint your code using `eslint` and `prettier --check` on every push changes to `src/**`

**Note**: Only merge this PR after you merged #30 and #31. Because this PR changes would not work properly because of the missing packages needed by `eslint` and `prettier` which I've added from PR's #30 and #31